### PR TITLE
Extend `getConnectionToken` to support string `connection` parameter

### DIFF
--- a/lib/common/knex.utils.ts
+++ b/lib/common/knex.utils.ts
@@ -27,8 +27,11 @@ export function getModelToken(
 }
 
 export function getConnectionToken(
-  connection: KnexModuleOptions | any = DEFAULT_CONNECTION_NAME,
+  connection: KnexModuleOptions | string = DEFAULT_CONNECTION_NAME,
 ): string | Function {
+  if (typeof connection === 'string') {
+    return connection;
+  }
   return `${connection.name || DEFAULT_CONNECTION_NAME}`;
 }
 


### PR DESCRIPTION
`KnexCoreModule.forRoot` called `getConnectionToken` with the string `connection` parameter to `export` it (in https://github.com/Tony133/nestjs-knexjs/blob/main/lib/knex-core.module.ts#L33=), yet `getConnectionToken` only supported a connection object; thus it always returned the default connection string. Changing this would make the library properly supports multiple database connection.